### PR TITLE
Fix parse_mode, NO_REPLY leak, and publish pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "openclaw": {
     "extensions": [
-      "."
+      "./index.ts"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,25 +3,22 @@
   "version": "1.0.2",
   "description": "File browser for OpenClaw workspace via Telegram inline buttons",
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./index.ts",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
+    ".": "./index.ts"
   },
   "files": [
-    "dist",
+    "src",
+    "index.ts",
     "openclaw.plugin.json",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "prepublishOnly": "npm run build && npm run test"
+    "prepublishOnly": "npm run test"
   },
   "repository": {
     "type": "git",

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -39,7 +39,7 @@ async function sendOrEditBrowser(
   const response = await callTelegramApi(botToken, "sendMessage", {
     chat_id: chatId,
     text: result.text,
-    parse_mode: "Markdown",
+    parse_mode: "HTML",
     reply_markup: { inline_keyboard: result.buttons },
   });
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -56,7 +56,7 @@ export async function handlebrowse(
   alwaysSendNew: boolean = false,
   config: PluginConfig,
   stateDir?: string
-): Promise<{ text: string }> {
+): Promise<{ text?: string }> {
   try {
     // Check if the message comes from Telegram
     if (ctx.channel !== "telegram") {
@@ -98,7 +98,7 @@ export async function handlebrowse(
     await sendOrEditBrowser(botToken, chatId, path, state, offset, alwaysSendNew, config, stateDir);
 
     // Return zero-width space - invisible indicator that we handled sending ourselves
-    return { text: "\u200B" };
+    return { };
   } catch (e: any) {
     return { text: `❌ Error: ${e.message}` };
   }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -97,7 +97,9 @@ export async function handlebrowse(
     // Send or edit the browser message directly via Telegram API
     await sendOrEditBrowser(botToken, chatId, path, state, offset, alwaysSendNew, config, stateDir);
 
-    return { text: "NO_REPLY" };
+    return alwaysSendNew
+      ? { text: "Use the buttons above to browse files." }
+      : { text: "NO_REPLY" };
   } catch (e: any) {
     return { text: `❌ Error: ${e.message}` };
   }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -97,8 +97,7 @@ export async function handlebrowse(
     // Send or edit the browser message directly via Telegram API
     await sendOrEditBrowser(botToken, chatId, path, state, offset, alwaysSendNew, config, stateDir);
 
-    // Return zero-width space - invisible indicator that we handled sending ourselves
-    return { };
+    return { text: "NO_REPLY" };
   } catch (e: any) {
     return { text: `❌ Error: ${e.message}` };
   }
@@ -145,7 +144,7 @@ export async function handleDownload(
 
     // Send the file via Telegram
     await sendFileViaTelegram(botToken, chatId, validatedPath);
-    return { text: "\u200B" }; // Zero-width space - invisible indicator we handled sending
+    return { text: "NO_REPLY" };
   } catch (e: any) {
     return { text: `❌ Error downloading file: ${e.message}` };
   }


### PR DESCRIPTION
## Summary

- **Fix `parse_mode` bug**: `sendMessage` was using `parse_mode: "Markdown"` while the browser generates HTML (`<b>`, `<code>` tags). This caused Telegram API errors on paths with Markdown special characters and rendered HTML tags as literal text. Changed to `parse_mode: "HTML"` to match `editMessageText`.
- **Fix NO_REPLY leak on `/browse`**: Instead of returning the silent `NO_REPLY` token when the user types `/browse` directly, reply with a short hint message ("Use the buttons above to browse files."). Button-click invocations still return `NO_REPLY` silently.
- **Fix duplicate browser messages**: Removed the `alwaysSendNew` bypass that ignored a stored message ID. The handler now always attempts `editMessageText` first and only falls back to `sendMessage` if the edit fails (message deleted or too old), preventing duplicate UI messages in race conditions.
- **Ship TypeScript sources directly**: Removed the compile step from `prepublishOnly`. The package now publishes `index.ts` + `src/` instead of `dist/`, since OpenClaw loads plugins via jiti. The `build` script is kept for type-checking only (`tsc --noEmit`).
- **Extension path compliance**: Updated `openclaw.plugin.json` extensions field to comply with the OpenClaw v2026.3.2 path validator (fixes #7).

## Test plan

- [x] Type `/browse` — browser UI appears, followed by one-line hint message
- [x] Click a folder button — browser updates silently (no extra message)
- [x] Click the download button — file is sent silently (no extra message)
- [x] Browse a directory with filenames containing `_`, `*`, or `[` — no API error
- [x] `npm publish --tag alpha --access public` — publishes TS sources, no build step runs